### PR TITLE
Switch to using GITHUB_ENV instead of set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@ output=$(/misspell-fixer/misspell-fixer $INPUT_OPTIONS)
 status="$?"
 
 # Sets the output variable for GitHub Action API:
-# See: https://help.github.com/en/articles/development-tools-for-github-action
-echo "::set-output name=output::$output"
+# See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+echo "output=$output" >> "$GITHUB_ENV"
 echo '================================='
 echo
 


### PR DESCRIPTION
This matches Github's currently recommended setup:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable

and fixes https://github.com/sobolevn/misspell-fixer-action/issues/10 'The `set-output` command is deprecated and will be disabled soon'.